### PR TITLE
Updated vault.tf to label instances as vault-#

### DIFF
--- a/iad/vault/vault.tf
+++ b/iad/vault/vault.tf
@@ -4,7 +4,7 @@ resource "oci_core_instance" "vault" {
   count               = 3
   availability_domain = "${lookup(data.oci_identity_availability_domains.ADs.availability_domains[count.index],"name")}"
   compartment_id      = "${data.terraform_remote_state.common.vault_compartment}"
-  display_name        = "consul-${count.index}"
+  display_name        = "vault-${count.index}"
   shape               = "${var.instance_shape}"
 
   create_vnic_details {


### PR DESCRIPTION
looks like possible cut and paste from the consul.tf, results in having multiple instances labeled consul-1, 2, 3 (still works fine, but looks strange in OCI console).